### PR TITLE
Call Converter Notes added to index page and gemfile updated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'devise'
 gem 'twilio-ruby', '4.13.0'
 gem 'phone', '1.2.3'
 gem 'icalendar', '2.4.1'
-gem 'geocoder', '1.4.4'
+gem 'geocoder', '1.4.7'
 gem 'aws-sdk', '~> 2.0'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,11 +80,10 @@ GEM
     ffi (1.9.23)
     figaro (1.1.1)
       thor (~> 0.14)
-    geocoder (1.4.4)
-    globalid (0.4.1)
-      activesupport (>= 4.2.0)
-    i18n (1.0.0)
-      concurrent-ruby (~> 1.0)
+    geocoder (1.4.7)
+    globalid (0.3.7)
+      activesupport (>= 4.1.0)
+    i18n (0.8.1)
     icalendar (2.4.1)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -208,7 +207,7 @@ DEPENDENCIES
   drip-ruby
   faker
   figaro
-  geocoder (= 1.4.4)
+  geocoder (= 1.4.7)
   icalendar (= 2.4.1)
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/views/api/v1/leads/index.json.jbuilder
+++ b/app/views/api/v1/leads/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.array!  @leads.each do |lead|
   json.(lead, :id, :first_name, :last_name, :email, :phone, :ip, :city, :state,
-  :zip, :contacted, :appointment_date, :created_at, :updated_at, :processed_within_minutes, :hot)
+  :zip, :contacted, :appointment_date, :created_at, :updated_at, :processed_within_minutes, :hot, :notes)
   json.events lead.events, :id, :lead_id, :name, :created_at, :updated_at
 end

--- a/app/views/leads/index.html.erb
+++ b/app/views/leads/index.html.erb
@@ -25,6 +25,7 @@
                 <th>Hot?</th>
                 <th>Appointment Date</th>
                 <th>Processed Within</th>
+                <th>Call Converter Notes</th>
               </tr>
             </thead>
             <tbody>
@@ -37,6 +38,7 @@
                 <td>{{ lead.hot }}</td>
                 <td>{{ moment(lead.appointment_date).format('dddd MMM Do YYYY, h:mm a') }}</td>
                 <td>{{ lead.processed_within_minutes }}</td>
+                <td>{{ lead.notes }}</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Updated gemfile to new geocoder 1.4.7 so edit leads page wouldn't break.
Added notes to json object and call it in the new call converter notes column in the index page.